### PR TITLE
Add WebP support

### DIFF
--- a/php/7.4.30-apache-bullseye/Dockerfile
+++ b/php/7.4.30-apache-bullseye/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/7.4.30-apache-buster/Dockerfile
+++ b/php/7.4.30-apache-buster/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/7.4.30-fpm-bullseye/Dockerfile
+++ b/php/7.4.30-fpm-bullseye/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/7.4.30-fpm-buster/Dockerfile
+++ b/php/7.4.30-fpm-buster/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.0.23-apache-bullseye/Dockerfile
+++ b/php/8.0.23-apache-bullseye/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.0.23-apache-buster/Dockerfile
+++ b/php/8.0.23-apache-buster/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.0.23-fpm-bullseye/Dockerfile
+++ b/php/8.0.23-fpm-bullseye/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.0.23-fpm-buster/Dockerfile
+++ b/php/8.0.23-fpm-buster/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.1.10-apache-bullseye/Dockerfile
+++ b/php/8.1.10-apache-bullseye/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.1.10-apache-buster/Dockerfile
+++ b/php/8.1.10-apache-buster/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.1.10-fpm-bullseye/Dockerfile
+++ b/php/8.1.10-fpm-bullseye/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.1.10-fpm-buster/Dockerfile
+++ b/php/8.1.10-fpm-buster/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.2.0RC1-apache-bullseye/Dockerfile
+++ b/php/8.2.0RC1-apache-bullseye/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.2.0RC1-apache-buster/Dockerfile
+++ b/php/8.2.0RC1-apache-buster/Dockerfile
@@ -47,7 +47,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -55,6 +55,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.2.0RC1-fpm-bullseye/Dockerfile
+++ b/php/8.2.0RC1-fpm-bullseye/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \

--- a/php/8.2.0RC1-fpm-buster/Dockerfile
+++ b/php/8.2.0RC1-fpm-buster/Dockerfile
@@ -46,7 +46,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_DISCARD_CHANGES=1 \
     COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     \
     (docker-php-ext-configure gd --with-freetype-dir=/usr/include/ && \
@@ -54,6 +54,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
         docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ || \
         docker-php-ext-configure gd --with-jpeg=/usr/include/) && \
+        docker-php-ext-configure gd --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     \
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \


### PR DESCRIPTION
This adds WebP support as it's a core feature in Wordpress and Drupal.

We're running into scenarios where images are not rendering because the Tugboat images are not configured to support WebP